### PR TITLE
Add ArgumentError on unwrapping nil values

### DIFF
--- a/lib/rubyfox/sfsobject/bulk.rb
+++ b/lib/rubyfox/sfsobject/bulk.rb
@@ -95,7 +95,7 @@ module Rubyfox
 
       def unwrap_value!(object, key)
         value = object.get(key)
-        raise ArgumentError.new("nil value for #{key.inspect}") unless value
+        raise ArgumentError, "nil value for #{key.inspect}" unless value
 
         if wrapper_method = _unwrapper(value)
           case wrapper_method

--- a/test/rubyfox/sfsobject/bulk_test.rb
+++ b/test/rubyfox/sfsobject/bulk_test.rb
@@ -12,6 +12,13 @@ class RubyfoxSFSObjectBulkTest < RubyfoxCase
     assert_conversion({ "key" => nil }, { :key => nil })
   end
 
+  test "raise ArgumentError for nil values" do
+    object = Rubyfox::SFSObject.new
+    assert_raises ArgumentError, :message => /nil value for :foo/ do
+      Rubyfox::SFSObject::Bulk.unwrap_value!(object, :foo)
+    end
+  end
+
   context "plain" do
     test "nil" do
       assert_conversion :null => nil


### PR DESCRIPTION
Stumbled a few times about this behaviour, changed the following Exception:

`NoMethodError: undefined method 'type_id' for nil:NilClass` 
_--> (requires "p-debugging")_

to

`ArgumentError: nil value for :effect` 
_--> (gives you hints about the cause of the problem)_
