### PR TITLE
Support loading of mixed arrays

### DIFF
--- a/lib/rubyfox/sfsobject/bulk.rb
+++ b/lib/rubyfox/sfsobject/bulk.rb
@@ -48,9 +48,7 @@ module Rubyfox
         "LONG_ARRAY"        =>  :getLongArray,
         "DOUBLE_ARRAY"      =>  :getDoubleArray,
         "SFS_OBJECT"        =>  proc { |k, v| to_hash(v.object) },
-        "SFS_ARRAY"         =>  proc do |k, v|
-          v.object.iterator.map { |e| to_hash(e.object) }
-        end
+        "SFS_ARRAY"         =>  proc { |k, v| to_array(v.object) }
       }
 
       # hash -> object
@@ -93,8 +91,18 @@ module Rubyfox
         hash
       end
 
+      def to_array(object)
+        object.iterator.each_with_index.map do |value, index|
+          _unwrap(object, index, value)
+        end
+      end
+
       def unwrap_value!(object, key)
         value = object.get(key)
+        _unwrap(object, key, value)
+      end
+
+      def _unwrap(object, key, value)
         raise ArgumentError, "nil value for #{key.inspect}" unless value
 
         if wrapper_method = _unwrapper(value)

--- a/test/rubyfox/sfsobject/bulk_test.rb
+++ b/test/rubyfox/sfsobject/bulk_test.rb
@@ -94,6 +94,21 @@ class RubyfoxSFSObjectBulkTest < RubyfoxCase
     test "sfsobject" do
       assert_conversion({ :sfsobject => [Rubyfox::SFSObject.new]}, { :sfsobject => [{}] })
     end
+
+    test "loads mixed arrays" do
+      object = Rubyfox::SFSObject.from_json('{"mixed": [
+        "foo",
+        true,
+        1.0,
+        {
+          "deep" => ["Föhn", "BÄR"]
+        }
+      ]}')
+      expected = {
+       :mixed => ["foo", true, 1.0, {:deep => ["Föhn", "BÄR"]}]
+      }
+      assert_equal expected, Rubyfox::SFSObject::Bulk.to_hash(object)
+    end
   end
 
   private


### PR DESCRIPTION
When loading a SFSObject from JSON it may contain mixed arrays. Support this by testing each member for the correct unwrap method.

Benchmarks:

```
BEFORE:

Warming up --------------------------------------
  empty: hash -> sfs    37.887k i/100ms
 empty: hash -[] sfs    39.001k i/100ms
  empty: json -> sfs    17.396k i/100ms
  empty: sfs -> hash    20.233k i/100ms
  empty: sfs -> json    32.715k i/100ms
  short: hash -> sfs     3.795k i/100ms
 short: hash -[] sfs     1.887k i/100ms
  short: json -> sfs     4.096k i/100ms
  short: sfs -> hash     2.715k i/100ms
  short: sfs -> json     4.437k i/100ms
   long: hash -> sfs   504.000  i/100ms
  long: hash -[] sfs   532.000  i/100ms
   long: json -> sfs   328.000  i/100ms
   long: sfs -> hash   285.000  i/100ms
   long: sfs -> json   534.000  i/100ms
Calculating -------------------------------------
  empty: hash -> sfs    651.630k (±15.6%) i/s -      3.183M
 empty: hash -[] sfs    638.351k (±17.9%) i/s -      3.081M
  empty: json -> sfs    236.218k (±30.4%) i/s -      1.061M
  empty: sfs -> hash    288.671k (±34.7%) i/s -      1.052M
  empty: sfs -> json    558.750k (±10.5%) i/s -      2.781M
  short: hash -> sfs     41.170k (±19.1%) i/s -    201.135k
 short: hash -[] sfs     43.298k (±18.1%) i/s -    209.457k
  short: json -> sfs     58.141k (±15.7%) i/s -    286.720k
  short: sfs -> hash     32.559k (±20.9%) i/s -    154.755k
  short: sfs -> json     52.228k (±21.3%) i/s -    248.472k
   long: hash -> sfs      6.627k (±17.3%) i/s -     31.752k
  long: hash -[] sfs      6.017k (±21.8%) i/s -     28.728k
   long: json -> sfs      3.981k (± 8.4%) i/s -     20.008k
   long: sfs -> hash      3.409k (±12.7%) i/s -     16.815k
   long: sfs -> json      6.519k (± 4.4%) i/s -     32.574k

AFTER:

Warming up --------------------------------------
  empty: hash -> sfs    38.965k i/100ms
 empty: hash -[] sfs    40.226k i/100ms
  empty: json -> sfs    19.019k i/100ms
  empty: sfs -> hash    22.016k i/100ms
  empty: sfs -> json    34.341k i/100ms
  short: hash -> sfs     5.026k i/100ms
 short: hash -[] sfs     4.752k i/100ms
  short: json -> sfs     5.556k i/100ms
  short: sfs -> hash     3.495k i/100ms
  short: sfs -> json     5.280k i/100ms
   long: hash -> sfs   642.000  i/100ms
  long: hash -[] sfs   639.000  i/100ms
   long: json -> sfs   447.000  i/100ms
   long: sfs -> hash   325.000  i/100ms
   long: sfs -> json   723.000  i/100ms
Calculating -------------------------------------
  empty: hash -> sfs    869.907k (± 6.2%) i/s -      4.325M
 empty: hash -[] sfs    830.306k (± 2.9%) i/s -      4.184M
  empty: json -> sfs    295.754k (±30.6%) i/s -      1.312M
  empty: sfs -> hash    356.237k (±36.3%) i/s -      1.277M
  empty: sfs -> json    653.636k (± 3.4%) i/s -      3.262M
  short: hash -> sfs     57.548k (± 9.2%) i/s -    286.482k
 short: hash -[] sfs     48.752k (±13.5%) i/s -    242.352k
  short: json -> sfs     71.114k (± 8.5%) i/s -    355.584k
  short: sfs -> hash     40.322k (±13.6%) i/s -    199.215k
  short: sfs -> json     65.236k (± 5.0%) i/s -    327.360k
   long: hash -> sfs      7.407k (±16.8%) i/s -     35.952k
  long: hash -[] sfs      6.890k (±19.5%) i/s -     33.228k
   long: json -> sfs      4.500k (± 5.9%) i/s -     22.797k
   long: sfs -> hash      2.954k (±14.5%) i/s -     14.625k
   long: sfs -> json      6.861k (± 7.0%) i/s -     34.704k
```
