### PR TITLE
Make compatible with JRuby 9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - jruby-9.1.13.0
+  - jruby-9.2.0.0
+  - jruby-9.1.17.0
   - jruby-1.7.27
 env:
   global:

--- a/lib/rubyfox/sfsobject/bulk.rb
+++ b/lib/rubyfox/sfsobject/bulk.rb
@@ -10,14 +10,14 @@ module Rubyfox
         String        =>  :putUtfString,
         TrueClass     =>  :putBool,
         FalseClass    =>  :putBool,
-        Fixnum        =>  :putInt,
+        Integer       =>  :putInt,
         Float         =>  :putDouble,
         Hash          =>  proc { |o, k, v| o.putSFSObject(k, to_sfs(v)) },
         Java::SFSObject => :putSFSObject,
         [String]      =>  :putUtfStringArray,
         [TrueClass]   =>  :putBoolArray,
         [FalseClass]  =>  :putBoolArray,
-        [Fixnum]      =>  proc do |o, k, v|
+        [Integer]     =>  proc do |o, k, v|
           collection = Java::ArrayList.new
           v.each { |e| collection.add(e.to_java(:int)) }
           o.putIntArray(k, collection)

--- a/lib/rubyfox/sfsobject/schema.rb
+++ b/lib/rubyfox/sfsobject/schema.rb
@@ -17,12 +17,12 @@ module Rubyfox
       TO_SFS = {
         String    => proc { |o, s, k, v| o.put_utf_string(k, v) },
         Boolean   => proc { |o, s, k, v| o.put_bool(k, v) },
-        Fixnum    => proc { |o, s, k, v| o.put_int(k, v) },
+        Integer   => proc { |o, s, k, v| o.put_int(k, v) },
         Float     => proc { |o, s, k, v| o.put_double(k, v) },
         Hash      => proc { |o, s, k, v| o.put_sfs_object(k, to_sfs(s, v)) },
         [String]  => proc { |o, s, k, v| o.put_utf_string_array(k, v) },
         [Boolean] => proc { |o, s, k, v| o.put_bool_array(k, v) },
-        [Fixnum]  =>  proc do |o, s, k, v|
+        [Integer] =>  proc do |o, s, k, v|
           collection = Java::ArrayList.new(v.size)
           v.each { |e| collection.add(e.to_java(:int)) }
           o.put_int_array(k, collection)
@@ -39,12 +39,12 @@ module Rubyfox
       TO_HASH = {
         String    => proc { |o, s, k| o.get_utf_string(k) },
         Boolean   => proc { |o, s, k| o.get_bool(k) },
-        Fixnum    => proc { |o, s, k| o.get_int(k) },
+        Integer   => proc { |o, s, k| o.get_int(k) },
         Float     => proc { |o, s, k| o.get_double(k) },
         Hash      => proc { |o, s, k| to_hash(s, o.get_sfs_object(k)) },
         [String]  => proc { |o, s, k| o.get_utf_string_array(k).to_a },
         [Boolean] => proc { |o, s, k| o.get_bool_array(k).to_a },
-        [Fixnum]  => proc { |o, s, k| o.get_int_array(k).to_a },
+        [Integer] => proc { |o, s, k| o.get_int_array(k).to_a },
         [Float]   => proc { |o, s, k| o.get_double_array(k).to_a },
         [Hash]    => proc { |o, s, k|
           sfs_ary = o.get_sfs_array(k)

--- a/test/rubyfox/sfsobject/accessor_test.rb
+++ b/test/rubyfox/sfsobject/accessor_test.rb
@@ -18,9 +18,9 @@ class RubyfoxSFSObjectAccessorTest < RubyfoxCase
 
   context "SFSObject[]" do
     test "sets hash" do
-      object = Rubyfox::SFSObject[:string => "value", :sub => { :fixnum => 23 }]
+      object = Rubyfox::SFSObject[:string => "value", :sub => { :integer => 23 }]
       assert_equal "value", object[:string]
-      assert_equal 23, object[:sub][:fixnum]
+      assert_equal 23, object[:sub][:integer]
     end
   end
 
@@ -51,21 +51,21 @@ class RubyfoxSFSObjectAccessorTest < RubyfoxCase
       assert_accessor :true => true, :false => false
     end
 
-    test "fixnum" do
-      assert_accessor :fixnum => 1
-      assert_accessor :fixnum => (2 ** 31 - 1)
-      assert_accessor :fixnum => -(2 ** 31)
+    test "integer" do
+      assert_accessor :integer => 1
+      assert_accessor :integer => (2 ** 31 - 1)
+      assert_accessor :integer => -(2 ** 31)
     end
 
-    test "fixnum too big for int" do
+    test "integer too big for int" do
       assert_raises RangeError, :message => /too big for int/ do
-        assert_accessor :fixnum => (2 ** 31)
+        assert_accessor :integer => (2 ** 31)
       end
     end
 
     test "cannot handle bignum" do
       assert_raises ArgumentError, :message => /Bignum/ do
-        assert_accessor :fixnum => (2 ** 63)
+        assert_accessor :integer => (2 ** 63)
       end
     end
 
@@ -92,8 +92,8 @@ class RubyfoxSFSObjectAccessorTest < RubyfoxCase
       assert_accessor :bool => [ true, false ]
     end
 
-    test "fixnum" do
-      assert_accessor :fixnum => [ 1, 2, 3 ]
+    test "integer" do
+      assert_accessor :integer => [ 1, 2, 3 ]
     end
 
     test "float" do

--- a/test/rubyfox/sfsobject/accessor_test.rb
+++ b/test/rubyfox/sfsobject/accessor_test.rb
@@ -64,7 +64,7 @@ class RubyfoxSFSObjectAccessorTest < RubyfoxCase
     end
 
     test "cannot handle bignum" do
-      assert_raises ArgumentError, :message => /Bignum/ do
+      assert_raises RangeError, :message => /bignum too big/ do
         assert_accessor :integer => (2 ** 63)
       end
     end

--- a/test/rubyfox/sfsobject/bulk_test.rb
+++ b/test/rubyfox/sfsobject/bulk_test.rb
@@ -46,7 +46,7 @@ class RubyfoxSFSObjectBulkTest < RubyfoxCase
     end
 
     test "cannot handle bignum" do
-      assert_raises ArgumentError, :message => /Bignum/ do
+      assert_raises RangeError, :message => /bignum too big/ do
         assert_conversion :integer => (2 ** 63)
       end
     end

--- a/test/rubyfox/sfsobject/bulk_test.rb
+++ b/test/rubyfox/sfsobject/bulk_test.rb
@@ -1,7 +1,7 @@
-# encoding: utf-8 
+# encoding: utf-8
 
-require 'helper'
-require 'rubyfox/sfsobject/bulk'
+require "helper"
+require "rubyfox/sfsobject/bulk"
 
 class RubyfoxSFSObjectBulkTest < RubyfoxCase
   test "empty" do
@@ -9,7 +9,7 @@ class RubyfoxSFSObjectBulkTest < RubyfoxCase
   end
 
   test "converts keys to symbols" do
-    assert_conversion({ "key" => nil }, { :key => nil })
+    assert_conversion({"key" => nil}, {:key => nil})
   end
 
   test "raise ArgumentError for nil values" do
@@ -33,21 +33,21 @@ class RubyfoxSFSObjectBulkTest < RubyfoxCase
       assert_conversion :true => true, :false => false
     end
 
-    test "fixnum" do
-      assert_conversion :fixnum => 1
-      assert_conversion :fixnum => (2 ** 31 - 1)
-      assert_conversion :fixnum => -(2 ** 31)
+    test "integer" do
+      assert_conversion :integer => 1
+      assert_conversion :integer => (2 ** 31 - 1)
+      assert_conversion :integer => -(2 ** 31)
     end
 
-    test "fixnum too big for int" do
+    test "integer too big for int" do
       assert_raises RangeError, :message => /too big for int/ do
-        assert_conversion :fixnum => (2 ** 31)
+        assert_conversion :integer => (2 ** 31)
       end
     end
 
     test "cannot handle bignum" do
       assert_raises ArgumentError, :message => /Bignum/ do
-        assert_conversion :fixnum => (2 ** 63)
+        assert_conversion :integer => (2 ** 63)
       end
     end
 
@@ -73,12 +73,12 @@ class RubyfoxSFSObjectBulkTest < RubyfoxCase
     end
 
     test "sub hashes" do
-      assert_conversion :sub => { :key => "value" }
-      assert_conversion :sub => { :deep => { :key => "value" } }
+      assert_conversion :sub => {:key => "value"}
+      assert_conversion :sub => {:deep => {:key => "value"}}
     end
 
     test "sfsobject" do
-      assert_conversion({ :sfsobject => Rubyfox::SFSObject.new }, { :sfsobject => {} })
+      assert_conversion({:sfsobject => Rubyfox::SFSObject.new}, {:sfsobject => {}})
     end
   end
 
@@ -91,15 +91,15 @@ class RubyfoxSFSObjectBulkTest < RubyfoxCase
     end
 
     test "boolean" do
-      assert_conversion :bool => [ true, false ]
+      assert_conversion :bool => [true, false]
     end
 
-    test "fixnum" do
-      assert_conversion :fixnum => [ 1, 2, 3 ]
+    test "integer" do
+      assert_conversion :integer => [1, 2, 3]
     end
 
     test "float" do
-      assert_conversion :float => [ 1.0, 1.0 / 3 ]
+      assert_conversion :float => [1.0, 1.0 / 3]
     end
 
     test "converts Java's double array to Ruby's Float array" do
@@ -119,12 +119,12 @@ class RubyfoxSFSObjectBulkTest < RubyfoxCase
     end
 
     test "sub hashes" do
-      assert_conversion :sub => [{ :key => "value" }]
-      assert_conversion :sub => [{ :deep => [{ :key => "value" }] }]
+      assert_conversion :sub => [{:key => "value"}]
+      assert_conversion :sub => [{:deep => [{:key => "value"}]}]
     end
 
     test "sfsobject" do
-      assert_conversion({ :sfsobject => [Rubyfox::SFSObject.new]}, { :sfsobject => [{}] })
+      assert_conversion({:sfsobject => [Rubyfox::SFSObject.new]}, {:sfsobject => [{}]})
     end
 
     test "loads mixed arrays" do
@@ -137,7 +137,7 @@ class RubyfoxSFSObjectBulkTest < RubyfoxCase
         }
       ]}')
       expected = {
-       :mixed => ["foo", true, 1.0, {:deep => ["Föhn", "BÄR"]}]
+        :mixed => ["foo", true, 1.0, {:deep => ["Föhn", "BÄR"]}],
       }
       assert_equal expected, Rubyfox::SFSObject::Bulk.to_hash(object)
     end
@@ -145,7 +145,7 @@ class RubyfoxSFSObjectBulkTest < RubyfoxCase
 
   private
 
-  def assert_conversion(input, output=input)
+  def assert_conversion(input, output = input)
     object = Rubyfox::SFSObject::Bulk.to_sfs(input)
     assert_equal output, Rubyfox::SFSObject::Bulk.to_hash(object)
   end

--- a/test/rubyfox/sfsobject/schema_test.rb
+++ b/test/rubyfox/sfsobject/schema_test.rb
@@ -26,15 +26,15 @@ class RubyfoxSFSObjectSchemaTest < RubyfoxCase
       assert_schema({ :bool => Boolean }, { :bool => false })
     end
 
-    test "fixnum" do
-      assert_schema({ :fixnum => Fixnum }, { :fixnum => 1 })
-      assert_schema({ :fixnum => Fixnum }, { :fixnum => (2 ** 31 - 1) })
-      assert_schema({ :fixnum => Fixnum }, { :fixnum => -(2 ** 31) })
+    test "integer" do
+      assert_schema({ :integer => Integer }, { :integer => 1 })
+      assert_schema({ :integer => Integer }, { :integer => (2 ** 31 - 1) })
+      assert_schema({ :integer => Integer }, { :integer => -(2 ** 31) })
     end
 
-    test "fixnum too big for int" do
+    test "integer too big for int" do
       assert_raises RangeError, :message => /too big for int/ do
-        assert_schema({ :fixnum => Fixnum }, { :fixnum => (2 ** 31) })
+        assert_schema({ :integer => Integer }, { :integer => (2 ** 31) })
       end
     end
 
@@ -69,9 +69,9 @@ class RubyfoxSFSObjectSchemaTest < RubyfoxCase
       assert_schema({ :bool => [Boolean] }, { :bool => [true, 23] }) # strange?
     end
 
-    test "fixnum" do
-      assert_schema({ :fixnum => [Fixnum] }, { :fixnum => [1, 2] })
-      assert_schema({ :fixnum => [Fixnum] }, { :fixnum => [(2 ** 31 - 1), -(2 ** 31)] })
+    test "integer" do
+      assert_schema({ :integer => [Integer] }, { :integer => [1, 2] })
+      assert_schema({ :integer => [Integer] }, { :integer => [(2 ** 31 - 1), -(2 ** 31)] })
     end
 
     test "float" do


### PR DESCRIPTION
This change would brake the compatibility with JRuby < 9.2.0.0, because of the `Fixnum` to `Integer` change.

Should we still support JRuby < 9.2.0.0?

@splattael @jnbt 